### PR TITLE
Issue #47: Wrap eth link updated 

### DIFF
--- a/src/containers/Vaults/CreateVault.tsx
+++ b/src/containers/Vaults/CreateVault.tsx
@@ -64,6 +64,11 @@ const CreateVault = ({
     const selectedCollateralDecimals = tokensFetchedData[selectedItem].decimals
     const haiBalanceUSD = useTokenBalanceInUSD('OD', rightInput ? rightInput : availableHai)
 
+    const redirectToWrapEth = () => {
+        const url = "https://wrapeth.com/";
+        window.open(url, "_blank");
+    };
+
     const selectedTokenBalance = useMemo(() => {
         if (selectedCollateralBalance) {
             return formatNumber(selectedCollateralBalance, 2)
@@ -134,12 +139,8 @@ const CreateVault = ({
     }
 
     const wrapEth = () => {
-        popupsActions.setSafeOperationPayload({
-            isOpen: true,
-            type: '',
-            isCreate: false,
-        })
-    }
+        redirectToWrapEth();
+    };
 
     const handleConfirm = async () => {
         if (account && library) {


### PR DESCRIPTION
closes #47

## Description
- When clicking wrap eth it'll open https://wrapeth.com/ in a new window
- Note that https://wrapeth.com/ only supports arbitrum & OP mainnet not the testnets. The other bridge that Joseph mentioned (https://app.optimism.io/bridge) doesn't actually support arbitrum - optimism bridging, it just links to other third-party bridges

## Screenshots

https://github.com/UseKeyp/od-app/assets/47253537/9e0d4dd4-e7be-484e-a81f-d2448b4cf6e3


