### PR TITLE
Issue #48: QA Vault details 

### DIFF
--- a/src/components/VaultStats.tsx
+++ b/src/components/VaultStats.tsx
@@ -9,14 +9,7 @@ import { useTokenBalanceInUSD, useSafeInfo } from '~/hooks'
 import { formatNumber, getRatePercentage, ratioChecker, returnState } from '~/utils'
 import { useStoreState } from '~/store'
 
-const VaultStats = ({
-    isModifying,
-    isDeposit,
-}: {
-    isModifying: boolean
-    isDeposit: boolean
-    isOwner: boolean
-}) => {
+const VaultStats = ({ isModifying, isDeposit }: { isModifying: boolean; isDeposit: boolean; isOwner: boolean }) => {
     const { t } = useTranslation()
     const {
         totalDebt: newDebt,
@@ -128,9 +121,13 @@ const VaultStats = ({
                                     <MainValue>{collateral}</MainValue>
                                     <MainChange>${collateralInUSD}</MainChange>
                                 </div>
-                                <AfterTextWrapper>
-                                    After: <span className={isDeposit ? 'green' : 'yellow'}>{newCollateral}</span>
-                                </AfterTextWrapper>
+                                {modified ? (
+                                    <AfterTextWrapper>
+                                        After: <span className={isDeposit ? 'green' : 'yellow'}>{newCollateral}</span>
+                                    </AfterTextWrapper>
+                                ) : (
+                                    <></>
+                                )}
                             </RowWrapper>
                         </Main>
 
@@ -141,9 +138,11 @@ const VaultStats = ({
                                     <MainValue>{totalDebt}</MainValue>
                                     <MainChange>${totalDebtInUSD}</MainChange>
                                 </div>
-                                <AfterTextWrapper>
-                                    After: <span className={isDeposit ? 'green' : 'yellow'}>{newDebt}</span>
-                                </AfterTextWrapper>
+                                {modified ? (
+                                    <AfterTextWrapper>
+                                        After: <span className={isDeposit ? 'green' : 'yellow'}>{newDebt}</span>
+                                    </AfterTextWrapper>
+                                ) : null}
                             </RowWrapper>
                         </Main>
 
@@ -154,21 +153,23 @@ const VaultStats = ({
                                     <RowTextWrapper>
                                         <MainValue>{singleSafe?.collateralRatio}%</MainValue>
                                         <MainChange>
-                                            <AfterTextWrapper>
-                                                <>
-                                                    After:{' '}
-                                                    <span
-                                                        className={returnState(
-                                                            ratioChecker(
-                                                                Number(newCollateralRatio),
-                                                                Number(collateralRatio)
-                                                            )
-                                                        ).toLowerCase()}
-                                                    >
-                                                        {newCollateralRatio}%
-                                                    </span>
-                                                </>
-                                            </AfterTextWrapper>
+                                            {modified ? (
+                                                <AfterTextWrapper>
+                                                    <>
+                                                        After:{' '}
+                                                        <span
+                                                            className={returnState(
+                                                                ratioChecker(
+                                                                    Number(newCollateralRatio),
+                                                                    Number(collateralRatio)
+                                                                )
+                                                            ).toLowerCase()}
+                                                        >
+                                                            {newCollateralRatio}%
+                                                        </span>
+                                                    </>
+                                                </AfterTextWrapper>
+                                            ) : null}
                                         </MainChange>
                                     </RowTextWrapper>
                                 </Column>

--- a/src/components/VaultStats.tsx
+++ b/src/components/VaultStats.tsx
@@ -12,7 +12,6 @@ import { useStoreState } from '~/store'
 const VaultStats = ({
     isModifying,
     isDeposit,
-    isOwner,
 }: {
     isModifying: boolean
     isDeposit: boolean
@@ -125,40 +124,26 @@ const VaultStats = ({
                         <Main>
                             <MainLabel>{singleSafe?.collateralName} Collateral</MainLabel>
                             <RowWrapper>
-                                <MainValue>
-                                    {collateral} {singleSafe?.collateralName}
-                                </MainValue>
-                                <MainChange>
-                                    {modified ? (
-                                        <>
-                                            After:{' '}
-                                            <span className={isDeposit ? 'green' : 'yellow'}>
-                                                {newCollateral} {singleSafe?.collateralName}
-                                            </span>
-                                        </>
-                                    ) : (
-                                        `$${collateralInUSD}`
-                                    )}
-                                </MainChange>
+                                <div>
+                                    <MainValue>{collateral}</MainValue>
+                                    <MainChange>${collateralInUSD}</MainChange>
+                                </div>
+                                <AfterTextWrapper>
+                                    After: <span className={isDeposit ? 'green' : 'yellow'}>{newCollateral}</span>
+                                </AfterTextWrapper>
                             </RowWrapper>
                         </Main>
 
                         <Main className="mid">
                             <MainLabel>OD Debt</MainLabel>
                             <RowWrapper>
-                                <MainValue>
-                                    {totalDebt} <span>OD</span>
-                                </MainValue>
-                                <MainChange>
-                                    {' '}
-                                    {modified ? (
-                                        <>
-                                            After: <span className={isDeposit ? 'green' : 'yellow'}>{newDebt} OD</span>
-                                        </>
-                                    ) : (
-                                        `$${totalDebtInUSD}`
-                                    )}
-                                </MainChange>
+                                <div>
+                                    <MainValue>{totalDebt}</MainValue>
+                                    <MainChange>${totalDebtInUSD}</MainChange>
+                                </div>
+                                <AfterTextWrapper>
+                                    After: <span className={isDeposit ? 'green' : 'yellow'}>{newDebt}</span>
+                                </AfterTextWrapper>
                             </RowWrapper>
                         </Main>
 
@@ -166,26 +151,26 @@ const VaultStats = ({
                             <ColumnWrapper>
                                 <Column>
                                     <MainLabel>Collateral Ratio (min {collateralRatio}%)</MainLabel>
-                                    <MainValue>{singleSafe?.collateralRatio}%</MainValue>
-                                    <MainChange>
-                                        {modified ? (
-                                            <>
-                                                After:{' '}
-                                                <span
-                                                    className={returnState(
-                                                        ratioChecker(
-                                                            Number(newCollateralRatio),
-                                                            Number(collateralRatio)
-                                                        )
-                                                    ).toLowerCase()}
-                                                >
-                                                    {newCollateralRatio}%
-                                                </span>
-                                            </>
-                                        ) : (
-                                            ''
-                                        )}
-                                    </MainChange>
+                                    <RowTextWrapper>
+                                        <MainValue>{singleSafe?.collateralRatio}%</MainValue>
+                                        <MainChange>
+                                            <AfterTextWrapper>
+                                                <>
+                                                    After:{' '}
+                                                    <span
+                                                        className={returnState(
+                                                            ratioChecker(
+                                                                Number(newCollateralRatio),
+                                                                Number(collateralRatio)
+                                                            )
+                                                        ).toLowerCase()}
+                                                    >
+                                                        {newCollateralRatio}%
+                                                    </span>
+                                                </>
+                                            </AfterTextWrapper>
+                                        </MainChange>
+                                    </RowTextWrapper>
                                 </Column>
                                 <Column>
                                     <MainLabel>Risk</MainLabel>
@@ -295,10 +280,59 @@ const Flex = styled.div`
     }
 `
 
+const RowTextWrapper = styled.div`
+    display: flex;
+    flex-direction: row;
+    color: ${(props) => props.theme.colors.customSecondary};
+    span {
+        margin-left: 0.5rem;
+        &.green,
+        &.low {
+            color: ${(props) => props.theme.colors.blueish};
+        }
+        &.yellow {
+            color: ${(props) => props.theme.colors.yellowish};
+        }
+        &.dimmed {
+            color: ${(props) => props.theme.colors.secondary};
+        }
+        &.medium {
+            color: ${(props) => props.theme.colors.yellowish};
+        }
+        &.high {
+            color: ${(props) => props.theme.colors.dangerColor};
+        }
+    }
+`
+
 const RowWrapper = styled.div`
     display: flex;
-    @media (max-width: 767px) {
-        flex-direction: column;
+    flex-direction: row;
+    justify-content: space-between;
+`
+
+const AfterTextWrapper = styled.span`
+    display: flex;
+    color: ${(props) => props.theme.colors.customSecondary};
+    span {
+        margin-left: 0.5rem;
+        color: ${(props) => props.theme.colors.blueish};
+        &.green,
+        &.low {
+            color: ${(props) => props.theme.colors.blueish};
+        }
+        &.yellow {
+            color: ${(props) => props.theme.colors.yellowish};
+        }
+        &.dimmed {
+            color: ${(props) => props.theme.colors.secondary};
+        }
+        &.medium {
+            color: ${(props) => props.theme.colors.yellowish};
+        }
+        &.high {
+            color: ${(props) => props.theme.colors.dangerColor};
+        }
     }
 `
 
@@ -317,6 +351,7 @@ const Wrapper = styled.div`
 
 const ColumnWrapper = styled.div`
     display: flex;
+    justify-content: space-between;
     gap: 24px;
 `
 


### PR DESCRIPTION
Closes #48 

## Description
- [X] Dollar value should be below token amount
- [X] Remove token from label
- [X] Right-align risk
- [X] Dollar values should remain below each value (including the after one)
- [X] After collateral component should be to the right of the collateral ratio
- [X] After collateral value font color should be blue

Only thing I'm not sure about is whether we want the "after: X" to always show up, even when the fields haven't been modified & if we want them to be "justify-content: space-between" or closer together

## Screenshots

Desktop

https://github.com/UseKeyp/od-app/assets/47253537/95a43aaf-a183-4359-9720-f120a3c09194

Mobile

https://github.com/UseKeyp/od-app/assets/47253537/482621ab-9530-4ae6-9015-a49dd67903a4


