### PR TITLE
Issue #90: QA cleanup - disconnect from modal, double copy button

### DIFF
--- a/src/components/ConnectedWalletInfo.tsx
+++ b/src/components/ConnectedWalletInfo.tsx
@@ -34,12 +34,6 @@ const ConnectedWalletInfo = () => {
         popupsActions.setIsConnectorsWalletOpen(true)
     }
 
-    const handleDisconnect = () => {
-        popupsActions.setIsConnectedWalletModalOpen(false)
-        ;(connector as any).close()
-        connectWalletActions.setStep(0)
-    }
-
     const formatConnectorName = () => {
         const name = Object.keys(SUPPORTED_WALLETS)
             .filter(
@@ -81,11 +75,7 @@ const ConnectedWalletInfo = () => {
             <DataContainer>
                 <Connection>
                     {t('connected_with')} {connector ? formatConnectorName() : 'N/A'}
-                    {!(connector instanceof MetaMask) && !(connector instanceof CoinbaseWallet) ? (
-                        <Button text={'disconnect'} onClick={handleDisconnect} />
-                    ) : (
-                        <Button text={'change'} onClick={handleChange} />
-                    )}
+                    <Button text={'change'} onClick={handleChange} />
                 </Connection>
 
                 <Address id="web3-account-identifier-row">

--- a/src/components/Icons/CopyIcon.tsx
+++ b/src/components/Icons/CopyIcon.tsx
@@ -3,20 +3,6 @@ import React from 'react'
 const CopyIcon = () => {
     return (
         <>
-            <svg
-                xmlns="http://www.w3.org/2000/svg"
-                width="16"
-                height="16"
-                viewBox="0 0 24 24"
-                fill="none"
-                stroke="currentColor"
-                strokeWidth="2"
-                strokeLinecap="round"
-                strokeLinejoin="round"
-            >
-                <rect x="9" y="9" width="13" height="13" rx="2" ry="2"></rect>
-                <path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"></path>
-            </svg>
             <svg width="16" height="17" viewBox="0 0 16 17" fill="none" xmlns="http://www.w3.org/2000/svg">
                 <g clipPath="url(#clip0_826_1019)">
                     <path

--- a/src/connectors/coinbaseWallet.ts
+++ b/src/connectors/coinbaseWallet.ts
@@ -25,7 +25,7 @@ export const [coinbaseWallet, hooks] = initializeConnector<CoinbaseWallet>(
             actions,
             options: {
                 url: URLS[parseInt(process.env.REACT_APP_NETWORK_ID || '0')][0],
-                appName: 'od-on-op',
+                appName: 'od-on-arb',
             },
         })
 )


### PR DESCRIPTION
Closes #90 

## Description
- Fixed disconnecting from wallet connect from wallet info modal throws error
- Fixed duplicate copy address buttons
- Change Coinbase Wallet app name from "od-on-op" to "od-on-arb"

## Screenshots

Before: copy button duplicated

<img width="422" alt="copy address duplicated" src="https://github.com/UseKeyp/od-app/assets/47253537/476e0325-e435-4636-9a95-d7be11137a67">

After: copy button fixed

<img width="541" alt="fixed copy address duplicated" src="https://github.com/UseKeyp/od-app/assets/47253537/9752e336-bf1c-4e53-8774-2fcf74628beb">

Before: disconnect error 

https://github.com/UseKeyp/od-app/assets/47253537/ba43e7dc-083f-4afa-b84b-00b67833c545

After: disconnect fixed

https://github.com/UseKeyp/od-app/assets/47253537/04da72b9-b00f-41fd-ab87-061fc3b90817


